### PR TITLE
Add minimal VPC CloudFormation stack

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,20 @@
 # msk-iam-oneclick
-One-click MSK IAM POC. CloudFormation provisions VPC, MSK (Serverless), EC2 client + IAM/SSM. A small FastAPI UI (profile-aware) deploys, tests (produce/consume via SASL/IAM), and tears down
+One-click MSK IAM POC. CloudFormation provisions VPC, MSK (Serverless), EC2 client + IAM/SSM. A small FastAPI UI (profile-aware) deploys, tests (produce/consume via SASL/IAM), and tears down.
+
+## VPC stack
+
+The `vpc.yml` template creates a minimal networking layer for the proof of concept:
+
+- `/22` VPC
+- three private subnets across Availability Zones for MSK
+- one public subnet for an EC2 client (set `CreateNAT=true` to place the client in a private subnet and create a NAT gateway)
+- internet gateway and optional NAT routing
+- security groups `EC2ClientSG` and `MSKSG` with rules allowing the EC2 client to reach MSK
+
+### Outputs
+
+- `VpcId`
+- `MskSubnetIds` – comma separated private subnets for MSK
+- `Ec2SubnetId` – subnet for the EC2 client
+- `Ec2SecurityGroupId`
+- `MskSecurityGroupId`

--- a/vpc.yml
+++ b/vpc.yml
@@ -1,0 +1,186 @@
+AWSTemplateFormatVersion: '2010-09-09'
+Description: Minimal VPC for MSK IAM POC
+
+Parameters:
+  CreateNAT:
+    Type: String
+    Default: 'false'
+    AllowedValues: ['true', 'false']
+    Description: Create NAT gateway and place EC2 in private subnet
+
+Conditions:
+  CreateNATCondition: !Equals [!Ref CreateNAT, 'true']
+
+Resources:
+  VPC:
+    Type: AWS::EC2::VPC
+    Properties:
+      CidrBlock: 10.0.0.0/22
+      EnableDnsHostnames: true
+      EnableDnsSupport: true
+      Tags:
+        - Key: Name
+          Value: !Sub '${AWS::StackName}-vpc'
+
+  InternetGateway:
+    Type: AWS::EC2::InternetGateway
+    Properties:
+      Tags:
+        - Key: Name
+          Value: !Sub '${AWS::StackName}-igw'
+
+  VPCGatewayAttachment:
+    Type: AWS::EC2::VPCGatewayAttachment
+    Properties:
+      VpcId: !Ref VPC
+      InternetGatewayId: !Ref InternetGateway
+
+  PublicSubnet:
+    Type: AWS::EC2::Subnet
+    Properties:
+      VpcId: !Ref VPC
+      CidrBlock: 10.0.0.0/26
+      AvailabilityZone: !Select [0, !GetAZs '']
+      MapPublicIpOnLaunch: true
+      Tags:
+        - Key: Name
+          Value: !Sub '${AWS::StackName}-public-az0'
+
+  PublicRouteTable:
+    Type: AWS::EC2::RouteTable
+    Properties:
+      VpcId: !Ref VPC
+      Tags:
+        - Key: Name
+          Value: !Sub '${AWS::StackName}-public-rt'
+
+  PublicRoute:
+    Type: AWS::EC2::Route
+    Properties:
+      RouteTableId: !Ref PublicRouteTable
+      DestinationCidrBlock: 0.0.0.0/0
+      GatewayId: !Ref InternetGateway
+
+  PublicSubnetRouteTableAssociation:
+    Type: AWS::EC2::SubnetRouteTableAssociation
+    Properties:
+      RouteTableId: !Ref PublicRouteTable
+      SubnetId: !Ref PublicSubnet
+
+  PrivateSubnet1:
+    Type: AWS::EC2::Subnet
+    Properties:
+      VpcId: !Ref VPC
+      CidrBlock: 10.0.0.64/26
+      AvailabilityZone: !Select [0, !GetAZs '']
+      MapPublicIpOnLaunch: false
+      Tags:
+        - Key: Name
+          Value: !Sub '${AWS::StackName}-private-az0'
+
+  PrivateSubnet2:
+    Type: AWS::EC2::Subnet
+    Properties:
+      VpcId: !Ref VPC
+      CidrBlock: 10.0.0.128/26
+      AvailabilityZone: !Select [1, !GetAZs '']
+      MapPublicIpOnLaunch: false
+      Tags:
+        - Key: Name
+          Value: !Sub '${AWS::StackName}-private-az1'
+
+  PrivateSubnet3:
+    Type: AWS::EC2::Subnet
+    Properties:
+      VpcId: !Ref VPC
+      CidrBlock: 10.0.0.192/26
+      AvailabilityZone: !Select [2, !GetAZs '']
+      MapPublicIpOnLaunch: false
+      Tags:
+        - Key: Name
+          Value: !Sub '${AWS::StackName}-private-az2'
+
+  PrivateRouteTable:
+    Type: AWS::EC2::RouteTable
+    Properties:
+      VpcId: !Ref VPC
+      Tags:
+        - Key: Name
+          Value: !Sub '${AWS::StackName}-private-rt'
+
+  PrivateRoute:
+    Type: AWS::EC2::Route
+    Condition: CreateNATCondition
+    Properties:
+      RouteTableId: !Ref PrivateRouteTable
+      DestinationCidrBlock: 0.0.0.0/0
+      NatGatewayId: !Ref NatGateway
+
+  PrivateSubnet1RouteTableAssociation:
+    Type: AWS::EC2::SubnetRouteTableAssociation
+    Properties:
+      RouteTableId: !Ref PrivateRouteTable
+      SubnetId: !Ref PrivateSubnet1
+
+  PrivateSubnet2RouteTableAssociation:
+    Type: AWS::EC2::SubnetRouteTableAssociation
+    Properties:
+      RouteTableId: !Ref PrivateRouteTable
+      SubnetId: !Ref PrivateSubnet2
+
+  PrivateSubnet3RouteTableAssociation:
+    Type: AWS::EC2::SubnetRouteTableAssociation
+    Properties:
+      RouteTableId: !Ref PrivateRouteTable
+      SubnetId: !Ref PrivateSubnet3
+
+  NatEIP:
+    Type: AWS::EC2::EIP
+    Condition: CreateNATCondition
+    Properties:
+      Domain: vpc
+
+  NatGateway:
+    Type: AWS::EC2::NatGateway
+    Condition: CreateNATCondition
+    Properties:
+      AllocationId: !GetAtt NatEIP.AllocationId
+      SubnetId: !Ref PublicSubnet
+      Tags:
+        - Key: Name
+          Value: !Sub '${AWS::StackName}-nat'
+
+  EC2ClientSG:
+    Type: AWS::EC2::SecurityGroup
+    Properties:
+      GroupDescription: EC2 client security group
+      VpcId: !Ref VPC
+      Tags:
+        - Key: Name
+          Value: !Sub '${AWS::StackName}-ec2-sg'
+
+  MSKSG:
+    Type: AWS::EC2::SecurityGroup
+    Properties:
+      GroupDescription: MSK security group
+      VpcId: !Ref VPC
+      SecurityGroupIngress:
+        - IpProtocol: tcp
+          FromPort: 9098
+          ToPort: 9098
+          SourceSecurityGroupId: !Ref EC2ClientSG
+      Tags:
+        - Key: Name
+          Value: !Sub '${AWS::StackName}-msk-sg'
+
+Outputs:
+  VpcId:
+    Value: !Ref VPC
+  MskSubnetIds:
+    Value: !Join [",", [!Ref PrivateSubnet1, !Ref PrivateSubnet2, !Ref PrivateSubnet3]]
+  Ec2SubnetId:
+    Value: !If [CreateNATCondition, !Ref PrivateSubnet1, !Ref PublicSubnet]
+  Ec2SecurityGroupId:
+    Value: !Ref EC2ClientSG
+  MskSecurityGroupId:
+    Value: !Ref MSKSG


### PR DESCRIPTION
## Summary
- add a CloudFormation template that provisions a /22 VPC with public and private subnets, optional NAT, and security groups for EC2 and MSK
- document the VPC stack and its outputs

## Testing
- `cfn-lint vpc.yml`
- `AWS_DEFAULT_REGION=us-east-1 aws cloudformation validate-template --template-body file://vpc.yml` *(fails: Unable to locate credentials)*

------
https://chatgpt.com/codex/tasks/task_e_68a84b34cddc832cb6d29623370f3c1c