### PR TITLE
Add profile-aware FastAPI scaffold

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,23 @@
 # msk-iam-oneclick
 One-click MSK IAM POC. CloudFormation provisions VPC, MSK (Serverless), EC2 client + IAM/SSM. A small FastAPI UI (profile-aware) deploys, tests (produce/consume via SASL/IAM), and tears down.
 
+## FastAPI app
+
+The `app/main.py` module exposes a minimal FastAPI form that asks for an
+AWS profile, region, stack name, and a simple feature toggle. Submitting the
+form creates a `boto3.Session` using the provided profile and region and
+returns the caller identity or an error if the profile is missing or invalid.
+
+Run locally with:
+
+```bash
+pip install fastapi uvicorn boto3
+uvicorn app.main:app --reload
+```
+
+Open <http://127.0.0.1:8000> in a browser and submit the form. An STS call is
+made to verify the profile, and the resulting identity is displayed on success.
+
 ## VPC stack
 
 The `vpc.yml` template creates a minimal networking layer for the proof of concept:

--- a/app/main.py
+++ b/app/main.py
@@ -1,0 +1,53 @@
+from fastapi import FastAPI, Form
+from fastapi.responses import HTMLResponse
+import boto3
+from botocore.exceptions import ProfileNotFound, NoCredentialsError, ClientError
+
+app = FastAPI()
+
+FORM_HTML = """
+<!doctype html>
+<html>
+  <body>
+    <h1>AWS Session Form</h1>
+    <form method="post">
+      <label>AWS Profile: <input type="text" name="profile" required></label><br>
+      <label>Region: <input type="text" name="region" required></label><br>
+      <label>Stack Name: <input type="text" name="stack_name" required></label><br>
+      <label>Enable Feature: <input type="checkbox" name="feature"></label><br>
+      <button type="submit">Submit</button>
+    </form>
+  </body>
+</html>
+"""
+
+@app.get("/", response_class=HTMLResponse)
+async def read_root() -> HTMLResponse:
+    """Return a simple HTML form for AWS session parameters."""
+    return HTMLResponse(content=FORM_HTML)
+
+@app.post("/", response_class=HTMLResponse)
+async def create_session(
+    profile: str = Form(...),
+    region: str = Form(...),
+    stack_name: str = Form(...),
+    feature: bool = Form(False),
+) -> HTMLResponse:
+    """Create a boto3 session based on form input and display result."""
+    try:
+        session = boto3.Session(profile_name=profile, region_name=region)
+        # Trigger a call to ensure session is valid
+        sts = session.client("sts")
+        identity = sts.get_caller_identity()
+        message = (
+            f"Created session for {identity['Arn']}<br>"
+            f"Stack: {stack_name}<br>"
+            f"Feature enabled: {feature}"
+        )
+        return HTMLResponse(content=message)
+    except ProfileNotFound:
+        return HTMLResponse(content="Profile not found", status_code=400)
+    except (NoCredentialsError, ClientError) as exc:
+        return HTMLResponse(content=f"Credentials error: {exc}", status_code=400)
+    except Exception as exc:  # pragma: no cover - unexpected errors
+        return HTMLResponse(content=f"Unexpected error: {exc}", status_code=500)


### PR DESCRIPTION
## Summary
- scaffold a minimal FastAPI form asking for AWS profile, region, stack name and a toggle
- create a per-request boto3 Session and report STS caller identity with basic error handling
- document how to run the FastAPI app locally

## Testing
- `pip install fastapi uvicorn boto3`
- `python -m py_compile app/main.py`
- `python - <<'PY'
import fastapi, boto3
print('fastapi', fastapi.__version__)
print('boto3', boto3.__version__)
PY`

------
https://chatgpt.com/codex/tasks/task_e_68a8505f571c832c8f52589c483c1ecf