### PR TITLE
Add MSK produce/consume test and move HTML templates

### DIFF
--- a/app/templates/deploy.html
+++ b/app/templates/deploy.html
@@ -1,0 +1,53 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <title>MSK IAM One-click Deploy</title>
+    <link
+      href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css"
+      rel="stylesheet">
+  </head>
+  <body class="p-3">
+    <h1 class="mb-4">Deploy stacks</h1>
+    <form id="deploy-form" class="mb-3">
+      <div class="mb-3">
+        <label class="form-label">AWS Profile</label>
+        <input class="form-control" name="profile" required>
+      </div>
+      <div class="mb-3">
+        <label class="form-label">Region</label>
+        <input class="form-control" name="region" required>
+      </div>
+      <div class="mb-3">
+        <label class="form-label">Stack Name</label>
+        <input class="form-control" name="stack_name" required>
+      </div>
+      <button class="btn btn-primary" type="submit">Deploy</button>
+    </form>
+    <pre id="events" class="border p-2 bg-light" style="height: 400px; overflow:auto;"></pre>
+    <script>
+    document.getElementById('deploy-form').addEventListener('submit', async function(e) {
+      e.preventDefault();
+      const log = document.getElementById('events');
+      log.textContent = '';
+      const formData = new FormData(e.target);
+      const response = await fetch('/deploy', {method: 'POST', body: formData});
+      const reader = response.body.getReader();
+      const decoder = new TextDecoder();
+      let buffer = '';
+      while (true) {
+        const {value, done} = await reader.read();
+        if (done) break;
+        buffer += decoder.decode(value, {stream: true});
+        const parts = buffer.split('\n\n');
+        buffer = parts.pop();
+        for (const part of parts) {
+          if (part.startsWith('data:')) {
+            log.textContent += part.slice(5).trim() + '\n';
+          }
+        }
+      }
+    });
+    </script>
+  </body>
+</html>

--- a/app/templates/session.html
+++ b/app/templates/session.html
@@ -1,0 +1,13 @@
+<!doctype html>
+<html>
+  <body>
+    <h1>AWS Session Form</h1>
+    <form method="post">
+      <label>AWS Profile: <input type="text" name="profile" required></label><br>
+      <label>Region: <input type="text" name="region" required></label><br>
+      <label>Stack Name: <input type="text" name="stack_name" required></label><br>
+      <label>Enable Feature: <input type="checkbox" name="feature"></label><br>
+      <button type="submit">Submit</button>
+    </form>
+  </body>
+</html>

--- a/app/templates/test.html
+++ b/app/templates/test.html
@@ -1,0 +1,57 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <title>MSK IAM Test</title>
+    <link
+      href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css"
+      rel="stylesheet">
+  </head>
+  <body class="p-3">
+    <h1 class="mb-4">Produce & Consume Test</h1>
+    <form id="test-form" class="mb-3">
+      <div class="mb-3">
+        <label class="form-label">AWS Profile</label>
+        <input class="form-control" name="profile" required>
+      </div>
+      <div class="mb-3">
+        <label class="form-label">Region</label>
+        <input class="form-control" name="region" required>
+      </div>
+      <div class="mb-3">
+        <label class="form-label">Stack Name</label>
+        <input class="form-control" name="stack_name" required>
+      </div>
+      <div class="mb-3">
+        <label class="form-label">Topic Name</label>
+        <input class="form-control" name="topic_name" required>
+      </div>
+      <button class="btn btn-primary" type="submit">Run Test</button>
+    </form>
+    <pre id="events" class="border p-2 bg-light" style="height: 400px; overflow:auto;"></pre>
+    <script>
+    document.getElementById('test-form').addEventListener('submit', async function(e) {
+      e.preventDefault();
+      const log = document.getElementById('events');
+      log.textContent = '';
+      const formData = new FormData(e.target);
+      const response = await fetch('/test', {method: 'POST', body: formData});
+      const reader = response.body.getReader();
+      const decoder = new TextDecoder();
+      let buffer = '';
+      while (true) {
+        const {value, done} = await reader.read();
+        if (done) break;
+        buffer += decoder.decode(value, {stream: true});
+        const parts = buffer.split('\n\n');
+        buffer = parts.pop();
+        for (const part of parts) {
+          if (part.startsWith('data:')) {
+            log.textContent += part.slice(5).trim() + '\n';
+          }
+        }
+      }
+    });
+    </script>
+  </body>
+</html>


### PR DESCRIPTION
## Summary
- move inline HTML into standalone templates
- add `/test` UI for producing 5 messages and consuming them back via SSM
- stream SSM command output to the page

## Testing
- `python -m py_compile app/main.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a852461c3c832cae4f8526953eae1e