### PR TITLE
Add guarded teardown endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,12 @@ AWS profile, region, stack name, and a simple feature toggle. Submitting the
 form creates a `boto3.Session` using the provided profile and region and
 returns the caller identity or an error if the profile is missing or invalid.
 
+Additional pages provide one-click stack management:
+
+- `/deploy` – create or update the CloudFormation stacks
+- `/test` – run a simple produce/consume test against the cluster
+- `/teardown` – delete the stacks in reverse order
+
 Run locally with:
 
 ```bash

--- a/app/templates/teardown.html
+++ b/app/templates/teardown.html
@@ -1,0 +1,53 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <title>MSK IAM Teardown</title>
+    <link
+      href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css"
+      rel="stylesheet">
+  </head>
+  <body class="p-3">
+    <h1 class="mb-4">Teardown stacks</h1>
+    <form id="teardown-form" class="mb-3">
+      <div class="mb-3">
+        <label class="form-label">AWS Profile</label>
+        <input class="form-control" name="profile" required>
+      </div>
+      <div class="mb-3">
+        <label class="form-label">Region</label>
+        <input class="form-control" name="region" required>
+      </div>
+      <div class="mb-3">
+        <label class="form-label">Stack Name</label>
+        <input class="form-control" name="stack_name" required>
+      </div>
+      <button class="btn btn-danger" type="submit">Teardown</button>
+    </form>
+    <pre id="events" class="border p-2 bg-light" style="height: 400px; overflow:auto;"></pre>
+    <script>
+    document.getElementById('teardown-form').addEventListener('submit', async function(e) {
+      e.preventDefault();
+      const log = document.getElementById('events');
+      log.textContent = '';
+      const formData = new FormData(e.target);
+      const response = await fetch('/teardown', {method: 'POST', body: formData});
+      const reader = response.body.getReader();
+      const decoder = new TextDecoder();
+      let buffer = '';
+      while (true) {
+        const {value, done} = await reader.read();
+        if (done) break;
+        buffer += decoder.decode(value, {stream: true});
+        const parts = buffer.split('\n\n');
+        buffer = parts.pop();
+        for (const part of parts) {
+          if (part.startsWith('data:')) {
+            log.textContent += part.slice(5).trim() + '\n';
+          }
+        }
+      }
+    });
+    </script>
+  </body>
+</html>


### PR DESCRIPTION
## Summary
- add CloudFormation teardown endpoint with concurrent-operation lock
- guard deploy/test endpoints to prevent overlap
- document and provide teardown HTML form

## Testing
- `python -m py_compile app/*.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a85374025c832cb155b56dc7cd7d9b