### PR TITLE
Scope MSK client IAM policy resources

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,11 @@ The `msk.yml` template provisions a minimal MSK Serverless cluster with IAM auth
 
 The `ec2.yml` template provisions a t3.micro Amazon Linux 2023 instance with an IAM role for SSM and MSK access.
 
+The role's `MskAccess` policy scopes `kafka-cluster` permissions to the
+specified cluster ARN as well as topic and consumer group ARNs derived from it.
+Topic and group resources retain a `*` wildcard suffix so that the `/test` flow
+can create and use arbitrary names.
+
 ### Parameters
 
 - `Ec2SubnetId` – subnet for the EC2 client

--- a/ec2.yml
+++ b/ec2.yml
@@ -38,11 +38,23 @@ Resources:
                 Action:
                   - kafka-cluster:Connect
                   - kafka-cluster:DescribeCluster
+                Resource: !Ref MskClusterArn
+              - Effect: Allow
+                Action:
                   - kafka-cluster:DescribeTopic
                   - kafka-cluster:CreateTopic
                   - kafka-cluster:ReadData
                   - kafka-cluster:WriteData
-                Resource: !Ref MskClusterArn
+                Resource:
+                  # Wildcard topic and group names so tests can create arbitrary resources
+                  - !Sub
+                      - 'arn:${AWS::Partition}:kafka:${AWS::Region}:${AWS::AccountId}:topic/${ClusterName}/${ClusterUuid}/*'
+                      - ClusterName: !Select [1, !Split ['/', !Ref MskClusterArn]]
+                        ClusterUuid: !Select [2, !Split ['/', !Ref MskClusterArn]]
+                  - !Sub
+                      - 'arn:${AWS::Partition}:kafka:${AWS::Region}:${AWS::AccountId}:group/${ClusterName}/${ClusterUuid}/*'
+                      - ClusterName: !Select [1, !Split ['/', !Ref MskClusterArn]]
+                        ClusterUuid: !Select [2, !Split ['/', !Ref MskClusterArn]]
 
   Ec2InstanceProfile:
     Type: AWS::IAM::InstanceProfile


### PR DESCRIPTION
## Summary
- scope MSK client IAM role to cluster, topic, and group ARNs
- document wildcard topic/group resources needed for tests

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a85503c5a0832c9c7b98b574094bba