### PR TITLE
Support importing existing Transit Gateway in network stack

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,9 @@ inbound resolver <----- outbound resolver
   `CreateNAT=true` to place the client in a private subnet and create a NAT
   gateway)
 - Transit Gateway with dedicated route table, VPC attachments, and routes to the
-  opposite CIDR blocks (toggle with `CreateTGW`)
+  opposite CIDR blocks. Provide `ExistingTransitGatewayId` to import an existing
+  Transit Gateway (stack must run in the same Region), otherwise a new one is
+  created.
 - Route 53 Resolver inbound endpoint in `VPC_MSK`, outbound endpoint and
   forwarding rule in `VPC_APP` (toggle with `CreateResolver`)
 - security groups `EC2ClientSG` and `MSKSG` allow the EC2 client to reach MSK on

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -68,6 +68,11 @@
               <label class="form-check-label" for="create-nat">CreateNAT</label>
             </div>
             <div class="mb-3">
+              <label class="form-label">Existing Transit Gateway ID (optional)</label>
+              <input class="form-control" id="tgwId">
+              <div class="form-text">Leave blank to create a new TGW. Must be in the same Region.</div>
+            </div>
+            <div class="mb-3">
               <label class="form-label">Topic Name</label>
               <input class="form-control" id="deploy-topic" value="poc-topic">
             </div>
@@ -167,9 +172,12 @@
         const profile = document.getElementById('deploy-profile').value;
         const connectivity = document.getElementById('connectivity-select').value;
         const createNat = document.getElementById('create-nat').checked;
+        const tgwId = document.getElementById('tgwId').value.trim();
         const topic = document.getElementById('deploy-topic').value;
         const logEl = document.getElementById('deploy-log'); logEl.textContent='';
-        startOp('/api/deploy', {profile, Connectivity:connectivity, CreateNAT:createNat, TopicName:topic}, logEl, outputs => {
+        const payload = {profile, Connectivity:connectivity, CreateNAT:createNat, TopicName:topic};
+        if(tgwId) payload.ExistingTransitGatewayId = tgwId;
+        startOp('/api/deploy', payload, logEl, outputs => {
           const out = document.getElementById('deploy-out');
           out.innerHTML = `<div class="card"><div class="card-body"><div>ClusterArn: ${outputs.ClusterArn}</div><div>BootstrapBrokers: ${outputs.BootstrapBrokers}</div><div>Ec2InstanceId: ${outputs.Ec2InstanceId}</div></div></div>`;
         });

--- a/infra/network.yaml
+++ b/infra/network.yaml
@@ -15,11 +15,11 @@ Parameters:
     Type: String
     Default: c2.kafka.us-east-1.amazonaws.com
     Description: Domain suffix for MSK broker hostnames (e.g., c2.kafka.us-east-1.amazonaws.com)
-  CreateTGW:
+  ExistingTransitGatewayId:
     Type: String
-    Default: 'true'
-    AllowedValues: ['true', 'false']
-    Description: Create Transit Gateway and related resources
+    Default: ''
+    AllowedPattern: '^$|^tgw-[0-9a-f]+$'
+    Description: Optional ID of an existing Transit Gateway (must be in the same Region)
   CreateResolver:
     Type: String
     Default: 'false'
@@ -28,7 +28,8 @@ Parameters:
 
 Conditions:
   CreateNATCondition: !Equals [!Ref CreateNAT, 'true']
-  CreateTGWCondition: !Equals [!Ref CreateTGW, 'true']
+  UseExistingTGW: !Not [!Equals [!Ref ExistingTransitGatewayId, '']]
+  CreateTGWCondition: !Equals [!Ref ExistingTransitGatewayId, '']
   CreateResolverCondition: !Equals [!Ref CreateResolver, 'true']
 
 Resources:
@@ -218,21 +219,18 @@ Resources:
 
   TransitGatewayRouteTable:
     Type: AWS::EC2::TransitGatewayRouteTable
-    Condition: CreateTGWCondition
     Properties:
-      TransitGatewayId: !Ref TransitGateway
+      TransitGatewayId: !If [UseExistingTGW, !Ref ExistingTransitGatewayId, !Ref TransitGateway]
       Tags:
         - Key: Name
           Value: !Sub '${AWS::StackName}-tgw-rt'
 
   TgwAttachmentApp:
     Type: AWS::EC2::TransitGatewayVpcAttachment
-    Condition: CreateTGWCondition
     DependsOn:
-      - TransitGateway
       - TransitGatewayRouteTable
     Properties:
-      TransitGatewayId: !Ref TransitGateway
+      TransitGatewayId: !If [UseExistingTGW, !Ref ExistingTransitGatewayId, !Ref TransitGateway]
       VpcId: !Ref VPCAPP
       SubnetIds:
         - !Ref AppPrivateSubnet
@@ -247,12 +245,10 @@ Resources:
 
   TgwAttachmentMsk:
     Type: AWS::EC2::TransitGatewayVpcAttachment
-    Condition: CreateTGWCondition
     DependsOn:
-      - TransitGateway
       - TransitGatewayRouteTable
     Properties:
-      TransitGatewayId: !Ref TransitGateway
+      TransitGatewayId: !If [UseExistingTGW, !Ref ExistingTransitGatewayId, !Ref TransitGateway]
       VpcId: !Ref VPCMSK
       SubnetIds:
         - !Ref MskSubnet1
@@ -267,35 +263,30 @@ Resources:
 
   TgwRouteTableAssociationApp:
     Type: AWS::EC2::TransitGatewayRouteTableAssociation
-    Condition: CreateTGWCondition
     Properties:
       TransitGatewayAttachmentId: !Ref TgwAttachmentApp
       TransitGatewayRouteTableId: !Ref TransitGatewayRouteTable
 
   TgwRouteTableAssociationMsk:
     Type: AWS::EC2::TransitGatewayRouteTableAssociation
-    Condition: CreateTGWCondition
     Properties:
       TransitGatewayAttachmentId: !Ref TgwAttachmentMsk
       TransitGatewayRouteTableId: !Ref TransitGatewayRouteTable
 
   TgwRouteTablePropagationApp:
     Type: AWS::EC2::TransitGatewayRouteTablePropagation
-    Condition: CreateTGWCondition
     Properties:
       TransitGatewayAttachmentId: !Ref TgwAttachmentApp
       TransitGatewayRouteTableId: !Ref TransitGatewayRouteTable
 
   TgwRouteTablePropagationMsk:
     Type: AWS::EC2::TransitGatewayRouteTablePropagation
-    Condition: CreateTGWCondition
     Properties:
       TransitGatewayAttachmentId: !Ref TgwAttachmentMsk
       TransitGatewayRouteTableId: !Ref TransitGatewayRouteTable
 
   TgwRouteApp:
     Type: AWS::EC2::TransitGatewayRoute
-    Condition: CreateTGWCondition
     Properties:
       TransitGatewayRouteTableId: !Ref TransitGatewayRouteTable
       DestinationCidrBlock: 10.1.0.0/22
@@ -303,7 +294,6 @@ Resources:
 
   TgwRouteMsk:
     Type: AWS::EC2::TransitGatewayRoute
-    Condition: CreateTGWCondition
     Properties:
       TransitGatewayRouteTableId: !Ref TransitGatewayRouteTable
       DestinationCidrBlock: 10.0.0.0/22
@@ -311,27 +301,24 @@ Resources:
 
   AppToMskTgwRoutePublic:
     Type: AWS::EC2::Route
-    Condition: CreateTGWCondition
     Properties:
       RouteTableId: !Ref AppPublicRouteTable
       DestinationCidrBlock: 10.0.0.0/22
-      TransitGatewayId: !Ref TransitGateway
+      TransitGatewayId: !If [UseExistingTGW, !Ref ExistingTransitGatewayId, !Ref TransitGateway]
 
   AppToMskTgwRoutePrivate:
     Type: AWS::EC2::Route
-    Condition: CreateTGWCondition
     Properties:
       RouteTableId: !Ref AppPrivateRouteTable
       DestinationCidrBlock: 10.0.0.0/22
-      TransitGatewayId: !Ref TransitGateway
+      TransitGatewayId: !If [UseExistingTGW, !Ref ExistingTransitGatewayId, !Ref TransitGateway]
 
   MskToAppTgwRoute:
     Type: AWS::EC2::Route
-    Condition: CreateTGWCondition
     Properties:
       RouteTableId: !Ref MskRouteTable
       DestinationCidrBlock: 10.1.0.0/22
-      TransitGatewayId: !Ref TransitGateway
+      TransitGatewayId: !If [UseExistingTGW, !Ref ExistingTransitGatewayId, !Ref TransitGateway]
 
   ResolverOutboundSG:
     Type: AWS::EC2::SecurityGroup
@@ -491,3 +478,5 @@ Outputs:
     Value: !Ref EC2ClientSG
   MskSecurityGroupId:
     Value: !Ref MSKSG
+  TransitGatewayId:
+    Value: !If [UseExistingTGW, !Ref ExistingTransitGatewayId, !Ref TransitGateway]


### PR DESCRIPTION
## Summary
- allow referencing an existing Transit Gateway via `ExistingTransitGatewayId`
- wire TGW resources/attachments to use the chosen TGW id
- document and surface the optional TGW id in README and UI

## Testing
- `cfn-lint infra/network.yaml`
- `python -m py_compile app/main.py`


------
https://chatgpt.com/codex/tasks/task_e_68ab18297f58832cb6be4ac97a3596b1