### PR TITLE
Set explicit Transit Gateway options

### DIFF
--- a/infra/network.yaml
+++ b/infra/network.yaml
@@ -209,6 +209,11 @@ Resources:
     Type: AWS::EC2::TransitGateway
     Condition: CreateTGWCondition
     Properties:
+      AmazonSideAsn: 64512
+      AutoAcceptSharedAttachments: enable
+      DefaultRouteTableAssociation: enable
+      DefaultRouteTablePropagation: enable
+      DnsSupport: enable
       Tags:
         - Key: Name
           Value: !Sub '${AWS::StackName}-tgw'


### PR DESCRIPTION
## Summary
- set AmazonSideAsn and enable key options on Transit Gateway to avoid creation errors

## Testing
- `cfn-lint infra/network.yaml`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68ab1b6d728c832c904a90ba10c6c90f