### PR TITLE
Parameterize TGW default associations

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,11 @@ inbound resolver <----- outbound resolver
   opposite CIDR blocks. Provide `ExistingTransitGatewayId` to import an existing
   Transit Gateway (stack must run in the same Region and account). Validate the
   ID beforehand with `aws ec2 describe-transit-gateways --transit-gateway-ids
-  <id>`; otherwise a new Transit Gateway is created.
+  <id>`; otherwise a new Transit Gateway is created. If the imported Transit
+  Gateway auto-associates attachments to its default route table, set
+  `TgwDefaultAssociationEnabled=true` to skip explicit associations or
+  disassociate existing ones before re-deploying with
+  `TgwDefaultAssociationEnabled=false`.
 - Route 53 Resolver inbound endpoint in `VPC_MSK`, outbound endpoint and
   forwarding rule in `VPC_APP` (toggle with `CreateResolver`)
 - security groups `EC2ClientSG` and `MSKSG` allow the EC2 client to reach MSK on

--- a/infra/network.yaml
+++ b/infra/network.yaml
@@ -20,6 +20,11 @@ Parameters:
     Default: ''
     AllowedPattern: '^$|^tgw-[0-9a-f]+$'
     Description: Optional ID of an existing Transit Gateway (must be in the same Region)
+  TgwDefaultAssociationEnabled:
+    Type: String
+    AllowedValues: ['true', 'false']
+    Default: 'false'
+    Description: Indicates if the Transit Gateway uses the default route table association
   CreateResolver:
     Type: String
     Default: 'false'
@@ -30,6 +35,7 @@ Conditions:
   CreateNATCondition: !Equals [!Ref CreateNAT, 'true']
   UseExistingTGW: !Not [!Equals [!Ref ExistingTransitGatewayId, '']]
   CreateTGWCondition: !Equals [!Ref ExistingTransitGatewayId, '']
+  CreateExplicitAssociation: !Equals [!Ref TgwDefaultAssociationEnabled, 'false']
   CreateResolverCondition: !Equals [!Ref CreateResolver, 'true']
 
 Resources:
@@ -211,8 +217,8 @@ Resources:
     Properties:
       AmazonSideAsn: 64512
       AutoAcceptSharedAttachments: enable
-      DefaultRouteTableAssociation: enable
-      DefaultRouteTablePropagation: enable
+      DefaultRouteTableAssociation: disable
+      DefaultRouteTablePropagation: disable
       DnsSupport: enable
       Tags:
         - Key: Name
@@ -270,12 +276,20 @@ Resources:
 
   TgwRouteTableAssociationApp:
     Type: AWS::EC2::TransitGatewayRouteTableAssociation
+    Condition: CreateExplicitAssociation
+    DependsOn:
+      - TransitGatewayRouteTable
+      - TgwAttachmentApp
     Properties:
       TransitGatewayAttachmentId: !Ref TgwAttachmentApp
       TransitGatewayRouteTableId: !Ref TransitGatewayRouteTable
 
   TgwRouteTableAssociationMsk:
     Type: AWS::EC2::TransitGatewayRouteTableAssociation
+    Condition: CreateExplicitAssociation
+    DependsOn:
+      - TransitGatewayRouteTable
+      - TgwAttachmentMsk
     Properties:
       TransitGatewayAttachmentId: !Ref TgwAttachmentMsk
       TransitGatewayRouteTableId: !Ref TransitGatewayRouteTable


### PR DESCRIPTION
## Summary
- add `TgwDefaultAssociationEnabled` parameter and `CreateExplicitAssociation` condition
- disable default TGW association/propagation and gate explicit associations
- document workflow for existing TGWs

## Testing
- `cfn-lint infra/network.yaml` (warnings: W3005 dependency already enforced)


------
https://chatgpt.com/codex/tasks/task_e_68ab24b158f4832cac1aae7ba7f13e1c